### PR TITLE
Adding minimal setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='finite-mdp',
+    version='1.0.dev0',
+    description='Gym environment for MDPs with finite state and action spaces',
+    url='https://github.com/eleurent/finite-mdp',
+    author='Edouard Leurent',
+    author_email='eleurent@gmail.com',
+    classifiers=[
+        'Intended Audience :: Researchers',
+        'Programming Language :: Python :: 3.5',
+    ],
+
+    keywords='finite mdp',
+    packages=find_packages(exclude=['docs', 'scripts', 'tests*']),
+    install_requires=['gym', 'numpy', 'matplotlib', 'torch>=1.2.0', 'networkx'],
+    tests_require=['pytest'],
+    extras_require={
+        'dev': ['scipy'],
+    },
+    entry_points={
+        'console_scripts': [],
+    },
+)


### PR DESCRIPTION
Hi @eleurent, this PR is raised with reference to issue ![#36](https://github.com/eleurent/rl-agents/issues/36). The `pip install` command specified by you raises an error for missing _setup.py_ file.

__Execution Note:__ Tested execution of planners_evaluation.py script with the finite-mdp module built from this setup.py script.

